### PR TITLE
Fix db:seed rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ require './lib/models/session'
 namespace :db do
   task :seed do
     Dir["data/*"].each do |directory|
+      next unless File.directory? directory
       year = Integer(directory.split(/\//).last)
 
       YAML.load(File.open(File.join(directory, "_sessions.yml"))).each do |number, attributes|


### PR DESCRIPTION
On import, the rake task was choking when it came across the LICENCE and README.md files in the data submodule dir. No harm done, but nobody likes an unnecessary exception... this fixes by skipping paths that are files rather than dirs.
