### PR TITLE
Fix some sessions appearing untranscribed

### DIFF
--- a/lib/models/session.rb
+++ b/lib/models/session.rb
@@ -29,7 +29,7 @@ class Session < Sequel::Model
   end
 
   def transcribed?
-    self.transcript and not (/false/ === self.transcript or self.transcript.empty?)
+    self.transcript and not ("false" === self.transcript or self.transcript.empty?)
   end
 
   def to_s


### PR DESCRIPTION
Any transcript that included the word "false" was appearing untranscribed, for example http://asciiwwdc.com/2013/sessions/413

Wasn't sure what the intention of the relevant clause is, so I just made it a literal match.

Thanks for providing the site, looking forward to getting a lot of use out of it next week! :8ball: 
