### PR TITLE
Fix: When `db:seed`ing, `ArgumentError: invalid value for Integer(): "tools"`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,9 +16,11 @@ namespace :db do
     
     Dir["data/*"].each do |directory|
       next unless File.directory? directory
-      next if directory == 'tools'
       
-      year = Integer(directory.split(/\//).last)
+      filename = directory.split(/\//).last
+      next if filename == 'tools'
+      
+      year = Integer(filename)
       next unless yearMatch == "#{year}" || yearMatch == "none"
       puts "\n#{year}\n----"
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ namespace :db do
     
     Dir["data/*"].each do |directory|
       next unless File.directory? directory
+      next if directory == 'tools'
       
       year = Integer(directory.split(/\//).last)
       next unless yearMatch == "#{year}" || yearMatch == "none"


### PR DESCRIPTION
Fixed an issue when running `rake db:seed` _(as instructed in the readme setup via `foreman run bundle exec rake db:seed`)_ where the `data/tools/` directory is interpreted as a year and dies with the following error:

~~~
rake aborted!
ArgumentError: invalid value for Integer(): "tools"
/Volumes/UserDrive/2016-04_10.11_Users/capnslipp/Development/Documentation/asciiwwdc.com/Rakefile:20:in `Integer'
/Volumes/UserDrive/2016-04_10.11_Users/capnslipp/Development/Documentation/asciiwwdc.com/Rakefile:20:in `block (3 levels) in <top (required)>'
/Volumes/UserDrive/2016-04_10.11_Users/capnslipp/Development/Documentation/asciiwwdc.com/Rakefile:17:in `each'
/Volumes/UserDrive/2016-04_10.11_Users/capnslipp/Development/Documentation/asciiwwdc.com/Rakefile:17:in `block (2 levels) in <top (required)>'
~~~

Fix is to simply skip to the next loop iteration if the directory's name is “tools”.  Not the most universal solution, but the least-invasive— I'd rather any new directory in the future also result in an error over silently ignoring all non-integer dir names. _(E.G. What if Apple changed their event timing and a new directory appeared as “2017-jan” or “nyc-2017”?  We'd want that not to be ignored without warning.)_