### PR TITLE
Fixed escaping for `@query`.

### DIFF
--- a/views/search.haml
+++ b/views/search.haml
@@ -1,6 +1,6 @@
 %article#search-results
   %header
-    %h1= "#{@sessions.count} #{@sessions.count == 1 ? "Result" : "Results"} for '#{@query}'"
+    %h1= "#{@sessions.count} #{@sessions.count == 1 ? "Result" : "Results"} for '#{html_escape @query}'"
 
   %dl
     - for session in @sessions

--- a/web.rb
+++ b/web.rb
@@ -34,7 +34,7 @@ class Web < Sinatra::Base
   end
 
   before do
-    @query = Rack::Utils.escape_html(params[:q]) if params[:q]
+    @query = params[:q] if params[:q]
 
     cache_control :public, max_age: 36000 unless @query
   end

--- a/web.rb
+++ b/web.rb
@@ -34,7 +34,7 @@ class Web < Sinatra::Base
   end
 
   before do
-    @query = params[:q] if params[:q]
+    @query = params[:q]
 
     cache_control :public, max_age: 36000 unless @query
   end


### PR DESCRIPTION
Fixed heavy-handed early escaping of `@query`, and ensured all usages of it (HTML header text, HTML form field value, DB query, & JSON output) are being properly escaped.

* Removed `Rack::Utils.escape_html(…)` from `Web`'s `before do`.
* Added a `html_escape` to `views/search.haml`— I'm not sure why it wasn't being escaped automatically (I don't see a `.raw` call or similar anywhere), but this properly escapes HTML stuff.  
	‣ Tested with the search string `<br/>` and it properly displayed a title of `0 Results for '<br/>'`.
* Verified that the `%input{type: 'search', name: 'q', …` in `views/layout.haml` is properly escaping its field value.  
	‣ Tested with the search string `"><br/>` and it properly delivered HTML `<input … name="q" … value="&quot;><br/>" …>`.
* Verified that the `Session.db[…]` call in `Session.search` is properly escaping `query`.  
	‣ Read over the docs regarding how `DB.literal` works and tried SQL injection strings.
* Verified that JSON search output is properly escaping the query.  
	‣ Tested with the search string `'"}` and it properly delivered JSON `{"query":"'\"}","results":[]}`.


Fixes ASCIIwwdc/asciiwwdc.com#29